### PR TITLE
feat: add block and report spoiler functionality

### DIFF
--- a/src/components/Auth/AuthDialog.tsx
+++ b/src/components/Auth/AuthDialog.tsx
@@ -19,7 +19,7 @@ import { useMutation } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import DicechoLogo from "./dicecho.svg";
 
-export const AuthDialog: FC<DialogProps> = ({ children, ...props }) => {
+export const AuthDialog: FC<DialogProps> = ({ children, onOpenChange, ...props }) => {
   const { t } = useTranslation();
 
   const { mutate: signInMutation, isPending } = useMutation({
@@ -38,6 +38,7 @@ export const AuthDialog: FC<DialogProps> = ({ children, ...props }) => {
     },
     onSuccess: () => {
       toast.success(t("sign_in_success"));
+      onOpenChange?.(false);
     },
     onError: (error) => {
       toast.error(t("sign_in_failed"), {
@@ -47,7 +48,7 @@ export const AuthDialog: FC<DialogProps> = ({ children, ...props }) => {
   });
 
   return (
-    <Dialog {...props}>
+    <Dialog onOpenChange={onOpenChange} {...props}>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className="p-4" showCloseButton={false}>
         <DialogHeader>

--- a/src/components/Auth/auth-button.tsx
+++ b/src/components/Auth/auth-button.tsx
@@ -1,34 +1,29 @@
 "use client";
 
 import { forwardRef } from "react";
-import { useSession } from "next-auth/react";
 import { Button, type ButtonProps } from "@/components/ui/button";
-import { AuthDialog } from "./AuthDialog";
+import { useAuthAction } from "./use-auth-action";
 
 /**
  * A button that requires authentication.
  * - If authenticated: executes onClick normally
- * - If not authenticated: opens AuthDialog on click
+ * - If not authenticated: opens AuthDialog, then executes onClick after successful login
  */
 export const AuthButton = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ onClick, children, ...props }, ref) => {
-    const { status } = useSession();
-    const isAuthenticated = status === "authenticated";
-
-    if (isAuthenticated) {
-      return (
-        <Button ref={ref} onClick={onClick} {...props}>
-          {children}
-        </Button>
-      );
-    }
+    const { requireAuth, AuthDialogPortal } = useAuthAction();
 
     return (
-      <AuthDialog>
-        <Button ref={ref} {...props}>
+      <>
+        <Button
+          ref={ref}
+          onClick={onClick ? requireAuth(onClick) : undefined}
+          {...props}
+        >
           {children}
         </Button>
-      </AuthDialog>
+        <AuthDialogPortal />
+      </>
     );
   },
 );

--- a/src/components/Auth/use-auth-action.tsx
+++ b/src/components/Auth/use-auth-action.tsx
@@ -1,0 +1,49 @@
+import { AuthDialog } from "./AuthDialog";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useAccount } from "@/hooks/useAccount";
+
+/**
+ * Hook that provides authentication-gated action execution.
+ * - If authenticated: executes callback immediately
+ * - If not authenticated: opens AuthDialog, then executes callback after successful login
+ * 
+ * @returns {Object}
+ * - requireAuth: wraps a callback to require authentication before execution
+ * - AuthDialogPortal: component that renders the AuthDialog (must be included in JSX)
+ */
+export function useAuthAction() {
+  const { isAuthenticated } = useAccount();
+  const [authOpen, setAuthOpen] = useState(false);
+  const pendingActionRef = useRef<(() => void) | null>(null);
+  const wasAuthenticatedRef = useRef(isAuthenticated);
+
+  // After successful login, the pending action will be executed automatically
+  useEffect(() => {
+    if (!wasAuthenticatedRef.current && isAuthenticated && pendingActionRef.current) {
+      pendingActionRef.current();
+      pendingActionRef.current = null;
+    }
+    wasAuthenticatedRef.current = isAuthenticated;
+  }, [isAuthenticated]);
+
+  const requireAuth = useCallback(
+    <T extends unknown[]>(callback: (...args: T) => void) => {
+      return (...args: T) => {
+        if (isAuthenticated) {
+          callback(...args);
+        } else {
+          pendingActionRef.current = () => callback(...args);
+          setAuthOpen(true);
+        }
+      };
+    },
+    [isAuthenticated]
+  );
+
+  const AuthDialogPortal = useCallback(
+    () => <AuthDialog open={authOpen} onOpenChange={setAuthOpen} />,
+    [authOpen]
+  );
+
+  return { requireAuth, AuthDialogPortal };
+}

--- a/src/components/Rate/RateItem.tsx
+++ b/src/components/Rate/RateItem.tsx
@@ -13,16 +13,19 @@ import { Badge } from "@/components/ui/badge";
 import { CommentSection } from "@/components/Comment";
 import { Button } from "@/components/ui/button";
 import { useSession } from "next-auth/react";
-import { MessageCircle, Edit, Trash2, Loader2, Languages, ThumbsUp, ThumbsDown, Laugh } from "lucide-react";
+import { MessageCircle, Edit, Trash2, Loader2, Languages, ThumbsUp, ThumbsDown, Laugh, EyeOff, AlertTriangle } from "lucide-react";
 import { ShareButton } from "@/components/ui/share-button";
 import { RateEditDialog } from "./RateEditDialog";
 import { RateDeleteDialog } from "./RateDeleteDialog";
+import { RateBlockDialog } from "./RateBlockDialog";
+import { RateSpoilerReportDialog } from "./RateSpoilerReportDialog";
 import { useRateTranslation } from "./use-rate-translation";
 import { SpoilerCollapsible } from "./spoiler-collapsible";
 import { FoldableContent } from "@/components/ui/foldable-content";
 import { cn } from "@/lib/utils";
 import { AuthButton } from "@/components/Auth/auth-button";
 import { useReactionDeclare } from "@/hooks/use-reaction-declare";
+import { useAccount } from "@/hooks/useAccount";
 
 interface IProps {
   rate: IRateDto;
@@ -38,7 +41,9 @@ export const RateItem: React.FunctionComponent<IProps> = ({
 }) => {
   const { t } = useTranslation();
   const [commentVisible, setCommentVisible] = useState(false);
-  
+  const { data: session } = useSession();
+  const { isAuthenticated } = useAccount();
+
   const { toggle, isActive, getCount } = useReactionDeclare({
     targetName: "Rate",
     targetId: rate._id,
@@ -58,10 +63,9 @@ export const RateItem: React.FunctionComponent<IProps> = ({
     targetLanguage,
   } = useRateTranslation(rate);
 
-  const { data: session, status } = useSession();
 
   const canEdit =
-    status === "authenticated" && rate.user._id === session?.user?._id;
+    isAuthenticated && rate.user._id === session?.user?._id;
 
   const rateUrl =
     typeof window !== "undefined"
@@ -276,6 +280,24 @@ export const RateItem: React.FunctionComponent<IProps> = ({
                   <span>{t("delete")}</span>
                 </Button>
               </RateDeleteDialog>
+            </>
+          )}
+
+          {!canEdit && (
+            <>
+              <RateSpoilerReportDialog rate={rate}>
+                <AuthButton size="sm" variant="secondary" className="gap-2">
+                  <AlertTriangle className="h-4 w-4" />
+                  <span>{t("report_spoiler")}</span>
+                </AuthButton>
+              </RateSpoilerReportDialog>
+
+              <RateBlockDialog rate={rate} onSuccess={onDeleted}>
+                <AuthButton size="sm" variant="secondary" className="gap-2">
+                  <EyeOff className="h-4 w-4" />
+                  <span>{t("block")}</span>
+                </AuthButton>
+              </RateBlockDialog>
             </>
           )}
         </div>

--- a/src/components/Rate/RateSpoilerReportDialog.tsx
+++ b/src/components/Rate/RateSpoilerReportDialog.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState, type PropsWithChildren } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import { useDicecho } from "@/hooks/useDicecho";
+import type { IRateDto } from "@dicecho/types";
+import { useTranslation } from "@/lib/i18n/react";
+
+interface RateSpoilerReportDialogProps {
+  rate: IRateDto;
+  onSuccess?: () => void;
+}
+
+export function RateSpoilerReportDialog({
+  rate,
+  onSuccess,
+  children,
+}: PropsWithChildren<RateSpoilerReportDialogProps>) {
+  const [open, setOpen] = useState(false);
+  const { api } = useDicecho();
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  const mutation = useMutation({
+    mutationFn: () => api.rate.reportSpoiler(rate._id),
+    onSuccess: () => {
+      setOpen(false);
+      queryClient.invalidateQueries({ queryKey: ["rate"] });
+      onSuccess?.();
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || t("error"));
+    },
+  });
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>{children}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t("report_spoiler_confirm_title")}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("report_spoiler_confirm_message")}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault();
+              mutation.mutate();
+            }}
+            disabled={mutation.isPending}
+          >
+            {t("confirm")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -241,6 +241,13 @@
   "rate_deleted": "Review deleted",
   "delete_rate_confirm_title": "Confirm Delete",
   "delete_rate_confirm_message": "Are you sure you want to delete this review? This action cannot be undone.",
+  "block": "Block",
+  "rate_blocked": "Review blocked successfully",
+  "block_rate_confirm_title": "Confirm Block",
+  "block_rate_confirm_message": "After blocking, this review will not appear in your list",
+  "report_spoiler": "Spoiler Warning",
+  "report_spoiler_confirm_title": "Spoiler Warning",
+  "report_spoiler_confirm_message": "Are you sure you want to report this review as a spoiler? Malicious abuse of warnings will be traced",
   "file_upload": {
     "drop_files": "Drop files here or",
     "browse_files": "browse files",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -213,6 +213,13 @@
   "rate_deleted": "評価を削除しました",
   "delete_rate_confirm_title": "削除の確認",
   "delete_rate_confirm_message": "この評価を削除してもよろしいですか？この操作は取り消せません。",
+  "block": "ブロック",
+  "rate_blocked": "評価をブロックしました",
+  "block_rate_confirm_title": "ブロックの確認",
+  "block_rate_confirm_message": "ブロックすると、この評価はあなたのリストに表示されなくなります",
+  "report_spoiler": "ネタバレ警告",
+  "report_spoiler_confirm_title": "ネタバレ警告",
+  "report_spoiler_confirm_message": "この評価をネタバレとして警告しますか？警告の悪用は追跡されます",
   "file_upload": {
     "drop_files": "ファイルをここにドロップするか",
     "browse_files": "ファイルを参照",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -241,6 +241,13 @@
   "rate_deleted": "리뷰가 삭제되었습니다",
   "delete_rate_confirm_title": "삭제 확인",
   "delete_rate_confirm_message": "이 리뷰를 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.",
+  "block": "차단",
+  "rate_blocked": "리뷰가 차단되었습니다",
+  "block_rate_confirm_title": "차단 확인",
+  "block_rate_confirm_message": "차단하면 이 리뷰가 목록에 표시되지 않습니다",
+  "report_spoiler": "스포일러 경고",
+  "report_spoiler_confirm_title": "스포일러 경고",
+  "report_spoiler_confirm_message": "이 리뷰를 스포일러로 경고하시겠습니까? 경고 남용은 추적됩니다",
   "file_upload": {
     "drop_files": "파일을 여기에 드롭하거나",
     "browse_files": "파일 찾아보기",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -241,6 +241,13 @@
   "rate_deleted": "评价已删除",
   "delete_rate_confirm_title": "确认删除",
   "delete_rate_confirm_message": "确定要删除这个评价吗？此操作无法撤销。",
+  "block": "屏蔽",
+  "rate_blocked": "评价屏蔽成功",
+  "block_rate_confirm_title": "确认屏蔽",
+  "block_rate_confirm_message": "屏蔽后该评价将不会显示在你的列表当中",
+  "report_spoiler": "剧透警告",
+  "report_spoiler_confirm_title": "剧透警告",
+  "report_spoiler_confirm_message": "确定要警告这条评价剧透么，恶意滥用警告会被追溯",
   "file_upload": {
     "drop_files": "拖放文件到此处或",
     "browse_files": "浏览文件",

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -358,6 +358,7 @@ export function createDicechoApi(opts: DicechoApiOptions) {
         payload: Partial<{ rate: number; remark: string; remarkType: string; type: number; view: number; isAnonymous: boolean; accessLevel: string }>,
       ) => request<typeof payload, IRateDto>(`/api/rate/${id}`, "PUT", payload),
       delete: (id: string) => request<Empty, Empty>(`/api/rate/${id}`, "DELETE"),
+      reportSpoiler: (id: string) => request<Empty, IRateDto>(`/api/rate/${id}/reportSpoiler`, "POST"),
     },
 
     like: {
@@ -430,6 +431,21 @@ export function createDicechoApi(opts: DicechoApiOptions) {
       markRead: (uuid: string) => request<Empty, INotificationDto>(`/api/notification/${uuid}/mark`, "POST"),
       markAllRead: () => request<Empty, Empty>(`/api/notification/markAll`, "POST"),
     },
+
+    block: {
+      block: (targetName: string, targetId: string) => 
+        request<{ targetName: string; targetId: string; }, Empty>(
+          `/api/block`,
+          "POST",
+          { targetName, targetId }
+        ),
+      cancel: (targetName: string, targetId: string) => 
+        request<{ targetName: string; targetId: string; }, Empty>(
+          `/api/block/cancel`,
+          "POST",
+          { targetName, targetId }
+        ),
+    }
   };
 }
 


### PR DESCRIPTION
<img width="400" alt="image" src="https://github.com/user-attachments/assets/27885c9b-4576-4f37-a6cc-d801d60dc8d6" />

新增了useAuthAction. 未登录状态下会弹出登录框，登陆后执行原本动作
![useAuthAction](https://github.com/user-attachments/assets/cf0bc49b-b6b0-4366-b5b3-60b65d434383)

close #10 
close #11