### PR TITLE
optimize: comment ux by drawer

### DIFF
--- a/src/components/Comment/comment-drawer.tsx
+++ b/src/components/Comment/comment-drawer.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useDicecho } from "@/hooks/useDicecho";
+import { useTranslation } from "@/lib/i18n/react";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import { CommentSection, type ReplyTarget } from "./comment-section";
+import { MobileCommentFooter } from "./mobile-comment-footer";
+import { useInvalidateReplies } from "./reply-section";
+
+interface CommentDrawerProps {
+  targetName: string;
+  targetId: string;
+  initialCount?: number;
+  children: React.ReactNode;
+}
+
+export function CommentDrawer({
+  targetName,
+  targetId,
+  initialCount = 0,
+  children,
+}: CommentDrawerProps) {
+  const { api } = useDicecho();
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const invalidateReplies = useInvalidateReplies();
+
+  const [open, setOpen] = useState(false);
+  const [replyTarget, setReplyTarget] = useState<ReplyTarget | null>(null);
+
+  // Clear reply target when drawer closes
+  useEffect(() => {
+    if (!open) {
+      setReplyTarget(null);
+    }
+  }, [open]);
+
+  const invalidateComments = async () => {
+    await queryClient.invalidateQueries({
+      queryKey: ["comments", targetName, targetId],
+      exact: false,
+    });
+  };
+
+  const handleReply = (target: ReplyTarget) => {
+    setReplyTarget(target);
+  };
+
+  const handleSubmit = async (content: string) => {
+    if (replyTarget) {
+      await api.comment.reply(replyTarget.id, { content });
+      await invalidateReplies(replyTarget.id);
+      await invalidateComments();
+    } else {
+      await api.comment.create(targetName, targetId, { content });
+      await invalidateComments();
+    }
+  };
+
+  const handleClearReply = () => {
+    setReplyTarget(null);
+  };
+
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <DrawerTrigger asChild>{children}</DrawerTrigger>
+      <DrawerContent className="flex max-h-[85vh] flex-col">
+        {/* Drag handle */}
+        <div className="mx-auto mt-2 h-1 w-10 shrink-0 rounded-full bg-muted" />
+
+        <DrawerHeader className="shrink-0 pb-2">
+          <DrawerTitle>
+            {initialCount > 0 ? `${initialCount} ` : ""}
+            {t("comments")}
+          </DrawerTitle>
+        </DrawerHeader>
+
+        {/* Scrollable comment list */}
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4">
+          <CommentSection
+            targetName={targetName}
+            targetId={targetId}
+            onReply={handleReply}
+            showComposer={false}
+          />
+        </div>
+
+        {/* Footer - relative position inside drawer */}
+        <MobileCommentFooter
+          variant="relative"
+          onSubmit={handleSubmit}
+          replyTargetId={replyTarget?.id}
+          replyToName={replyTarget?.name}
+          replyToContent={replyTarget?.contentPreview}
+          onClearReply={handleClearReply}
+        />
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/components/Comment/index.ts
+++ b/src/components/Comment/index.ts
@@ -5,5 +5,6 @@ export * from "./comment-composer";
 export * from "./comment-dialog-modal";
 export * from "./comment-thread";
 export * from "./comment-panel";
+export * from "./comment-drawer";
 export * from "./reply-section";
 export * from "./reply-item";

--- a/src/components/Comment/mobile-comment-footer.tsx
+++ b/src/components/Comment/mobile-comment-footer.tsx
@@ -19,6 +19,8 @@ interface MobileCommentFooterProps {
   onSubmit: (content: string) => Promise<void>;
   onClearReply?: () => void;
   className?: string;
+  /** Position variant: "fixed" for standalone pages, "relative" for use inside drawers */
+  variant?: "fixed" | "relative";
 }
 
 export const MobileCommentFooter: React.FC<MobileCommentFooterProps> = ({
@@ -29,6 +31,7 @@ export const MobileCommentFooter: React.FC<MobileCommentFooterProps> = ({
   onSubmit,
   onClearReply,
   className,
+  variant = "fixed",
 }) => {
   const { t } = useTranslation();
   const { status } = useSession();
@@ -73,7 +76,8 @@ export const MobileCommentFooter: React.FC<MobileCommentFooterProps> = ({
     return (
       <div
         className={cn(
-          "fixed inset-x-0 bottom-0 z-5 border-t bg-background px-4 py-2 shadow-[0_-2px_10px_rgba(0,0,0,0.1)] md:hidden",
+          "border-t bg-background px-4 py-2 shadow-[0_-2px_10px_rgba(0,0,0,0.1)]",
+          variant === "fixed" && "fixed inset-x-0 bottom-0 z-5 md:hidden",
           className
         )}
       >
@@ -94,7 +98,8 @@ export const MobileCommentFooter: React.FC<MobileCommentFooterProps> = ({
   return (
     <div
       className={cn(
-        "fixed inset-x-0 bottom-0 z-5 border-t bg-background px-4 py-2 shadow-[0_-2px_10px_rgba(0,0,0,0.1)] md:hidden",
+        "border-t bg-background px-4 py-2 shadow-[0_-2px_10px_rgba(0,0,0,0.1)]",
+        variant === "fixed" && "fixed inset-x-0 bottom-0 z-5 md:hidden",
         className
       )}
     >

--- a/src/components/Rate/RateItem.tsx
+++ b/src/components/Rate/RateItem.tsx
@@ -10,7 +10,7 @@ import { Rate } from "@/components/ui/rate";
 import { Trans } from "react-i18next";
 import { useTranslation } from "@/lib/i18n/react";
 import { Badge } from "@/components/ui/badge";
-import { CommentSection } from "@/components/Comment";
+import { CommentSection, CommentDrawer } from "@/components/Comment";
 import { Button } from "@/components/ui/button";
 import { useSession } from "next-auth/react";
 import { MessageCircle, Edit, Trash2, Loader2, Languages, ThumbsUp, ThumbsDown, Laugh, EyeOff, AlertTriangle, MoreHorizontal } from "lucide-react";
@@ -365,19 +365,19 @@ export const RateItem: React.FunctionComponent<IProps> = ({
 
           {!hideComments && (
             <>
-              {/* Mobile: Link to detail page */}
-              <LinkWithLng
-                href={`/rate/${rate._id}`}
-                className="md:hidden"
-                onClick={prefillDetailCache}
+              {/* Mobile: Open comment drawer */}
+              <CommentDrawer
+                targetName="Rate"
+                targetId={rate._id}
+                initialCount={rate.commentCount}
               >
-                <Button size="sm" variant="secondary" className="gap-1">
+                <Button size="sm" variant="secondary" className="gap-1 md:hidden">
                   <MessageCircle className="h-4 w-4" />
                   {rate.commentCount > 0 && (
                     <span>{rate.commentCount}</span>
                   )}
                 </Button>
-              </LinkWithLng>
+              </CommentDrawer>
 
               {/* Desktop: Expand comment section */}
               <Button


### PR DESCRIPTION
现在移动端点击 comment 按钮会自下而上弹出来一个 drawer, 避免了进入单独页面后重新加载 rate

<img width="411" height="684" alt="image" src="https://github.com/user-attachments/assets/3e421404-b23c-4e55-b29d-2ffd98b4ba30" />
